### PR TITLE
Added voodoo.py - Like magic.py but limits json imports to only current and child directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,15 @@ Slap a json file somewhere on your python path. ``tester.json``:
         }
     }
 
-Now import jsonsempai and your json file!
+Magic
+~~~~~
+
+Now import jsonsempai and import any json file residing on your Python path! 
 
 .. code:: python
 
     >>> from jsonsempai import magic
+    >>> # ../Python27/Scripts/tester.json
     >>> import tester
     >>> tester
     <module 'tester' from 'tester.json'>
@@ -51,7 +55,30 @@ Now import jsonsempai and your json file!
     u'nested'
     >>>
 
-Alternatively, a context manager may be used (100% less magic):
+
+Voodoo
+~~~~~~
+
+Similar to Magic, but is limited to json files in the same directory
+
+.. code:: python
+
+    >>> from jsonsempai import voodoo
+    >>> # /Python27/Scripts/tester.json
+    >>> import tester
+    ImportError: No module named tester_
+    >>> # /foobar/voodoo_tester.json
+    >>> import voodo_tester
+    >>> voodoo_tester
+    <module 'voodoo_tester' from 'voodoo_tester.json'>
+    >>> voodoo_tester.hello
+    u'world'
+    >>> voodoo_tester.this.can.be
+    u'nested'
+    >>>
+
+
+Alternatively, a context manager may be used (100% less magic, 0% voodoo):
 
 .. code:: python
 

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -38,7 +38,44 @@ class SempaiLoader(object):
         mod.__loader__ = self
 
         decoder = json.JSONDecoder(object_hook=DottedDict)
-        
+
+        try:
+            with open(self.json_path) as f:
+                d = decoder.decode(f.read())
+        except ValueError:
+            raise ImportError(
+                '"{name}" does not contain valid json.'.format(name=self.json_path))
+        except:
+            raise ImportError(
+                'Could not open "{name}".'.format(name=self.json_path))
+
+        mod.__dict__.update(d)
+
+        sys.modules[name] = mod
+        return mod
+
+
+class SempaiContextLoader(object):
+    def __init__(self, json_path):
+        self.json_path = json_path
+
+    @classmethod
+    def find_module(cls, name, path=None):
+        for d, _, _ in os.walk(os.path.abspath(os.curdir)):
+            json_path = os.path.join(d, '{name}.json'.format(name=name))
+            if os.path.isfile(json_path):
+                return cls(json_path)
+
+    def load_module(self, name):
+        if name in sys.modules:
+            return sys.modules[name]
+
+        mod = imp.new_module(name)
+        mod.__file__ = self.json_path
+        mod.__loader__ = self
+
+        decoder = json.JSONDecoder(object_hook=DottedDict)
+
         try:
             with open(self.json_path) as f:
                 d = decoder.decode(f.read())
@@ -62,3 +99,4 @@ def imports():
         yield
     finally:
         sys.meta_path.remove(SempaiLoader)
+

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -61,6 +61,11 @@ class SempaiContextLoader(object):
 
     @classmethod
     def find_module(cls, name, path=None):
+
+        if '.' in name:
+            name = name.split('.')
+            name = os.path.join(*name)
+
         for d, _, _ in os.walk(os.path.abspath(os.curdir)):
             json_path = os.path.join(d, '{name}.json'.format(name=name))
             if os.path.isfile(json_path):

--- a/jsonsempai/voodoo.py
+++ b/jsonsempai/voodoo.py
@@ -1,0 +1,5 @@
+import sys
+
+from .sempai import SempaiContextLoader
+
+sys.meta_path.append(SempaiContextLoader)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as file_readme:
     readme = file_readme.read()
 
 setup(name='json-sempai',
-      version='0.3.1',
+      version='0.3.2',
       description='Use JSON files as if they\'re python modules',
       long_description=readme,
       author='Louis Taylor',


### PR DESCRIPTION
I added an extra Loader called SempaiContextLoader, and it walks, starting from the current directory, down the subdirectories checking for the desired json file.

Edit: also updated readme to show new usage