### PR TITLE
notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.idea

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ python module.
 Usage
 -----
 
-Slap a json file somewhere on your python path. ``tester.json``:
+Slap a json file somewhere on your python path. ``me.json``:
 
 .. code:: json
 
@@ -42,12 +42,12 @@ Now import jsonsempai and your json file!
 .. code:: python
 
     >>> from jsonsempai import magic
-    >>> import tester
-    >>> tester
-    <module 'tester' from 'tester.json'>
-    >>> tester.hello
+    >>> import me
+    >>> me
+    <module 'me' from 'me.json'>
+    >>> me.hello
     u'world'
-    >>> tester.this.can.be
+    >>> me.this.can.be
     u'nested'
     >>>
 
@@ -56,10 +56,10 @@ Alternatively, a context manager may be used (100% less magic):
 .. code:: python
 
     >>> import jsonsempai
-    >>> with jsonsempai.imports():
-    ...     import tester
-    >>> tester
-    <module 'tester' from 'tester.json'>
+    >>> with jsonsempai.notice():
+    ...     import me
+    >>> me
+    <module 'me' from 'me.json'>
 
 
 Python packages are also supported:

--- a/jsonsempai/__init__.py
+++ b/jsonsempai/__init__.py
@@ -1,2 +1,2 @@
-from .sempai import imports
+from .sempai import notice
 from . import tests

--- a/jsonsempai/__init__.py
+++ b/jsonsempai/__init__.py
@@ -1,2 +1,2 @@
-from .sempai import notice
+from .sempai import notice, imports
 from . import tests

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -18,7 +18,7 @@ class DottedDict(dict):
 
 
 def get_json_path(directory, name):
-    json_path = os.path.join(directory, '{name}.json'.format(name=name))
+    json_path = os.path.join(directory, '{}.json'.format(name))
     if os.path.isfile(json_path):
         return json_path
 
@@ -56,15 +56,19 @@ class SempaiLoader(object):
                 d = decoder.decode(f.read())
         except ValueError:
             raise ImportError(
-                    '"{name}" does not contain valid json.'.format(name=self.json_path))
+                    '"{}" does not contain valid json.'.format(self.json_path))
         except:
             raise ImportError(
-                    'Could not open "{name}".'.format(name=self.json_path))
+                    'Could not open "{}".'.format(self.json_path))
 
         mod.__dict__.update(d)
 
         sys.modules[name] = mod
         return mod
+
+
+def imports():
+    notice()
 
 
 @contextlib.contextmanager

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -1,12 +1,11 @@
 import contextlib
-import imp
+import types
 import json
 import os
 import sys
 
 
 class DottedDict(dict):
-
     def __getattr__(self, attr):
         try:
             return self[attr]
@@ -42,12 +41,11 @@ class SempaiLoader(object):
                 if json_path is not None:
                     return cls(json_path)
 
-
     def load_module(self, name):
         if name in sys.modules:
             return sys.modules[name]
 
-        mod = imp.new_module(name)
+        mod = types.ModuleType(name)
         mod.__file__ = self.json_path
         mod.__loader__ = self
 
@@ -58,10 +56,10 @@ class SempaiLoader(object):
                 d = decoder.decode(f.read())
         except ValueError:
             raise ImportError(
-                '"{name}" does not contain valid json.'.format(name=self.json_path))
+                    '"{name}" does not contain valid json.'.format(name=self.json_path))
         except:
             raise ImportError(
-                'Could not open "{name}".'.format(name=self.json_path))
+                    'Could not open "{name}".'.format(name=self.json_path))
 
         mod.__dict__.update(d)
 
@@ -70,7 +68,7 @@ class SempaiLoader(object):
 
 
 @contextlib.contextmanager
-def imports():
+def notice():
     try:
         sys.meta_path.append(SempaiLoader)
         yield

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -18,7 +18,7 @@ class DottedDict(dict):
 
 
 def get_json_path(directory, name):
-    json_path = os.path.join(directory, '{}.json'.format(name))
+    json_path = os.path.join(directory, '{name}.json'.format(name=name))
     if os.path.isfile(json_path):
         return json_path
 
@@ -56,10 +56,10 @@ class SempaiLoader(object):
                 d = decoder.decode(f.read())
         except ValueError:
             raise ImportError(
-                    '"{}" does not contain valid json.'.format(self.json_path))
+                    '"{name}" does not contain valid json.'.format(name=self.json_path))
         except:
             raise ImportError(
-                    'Could not open "{}".'.format(self.json_path))
+                    'Could not open "{name}".'.format(name=self.json_path))
 
         mod.__dict__.update(d)
 

--- a/jsonsempai/tests/test_sempai.py
+++ b/jsonsempai/tests/test_sempai.py
@@ -37,33 +37,33 @@ class TestSempai(unittest.TestCase):
         shutil.rmtree(self.direc)
 
     def test_import(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertTrue(sempai is not None)
 
     def test_access(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual(3, sempai.three)
 
     def test_access_nested(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual(3, sempai.one.two.three)
 
     def test_acts_like_dict(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual({"three": 3}, sempai.one.two)
 
     def test_set(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         sempai.one.two.three = 4
         self.assertEqual(4, sempai.one.two.three)
 
     def test_del(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         del sempai.one.two.three
         self.assertEqual('not at home',
@@ -71,28 +71,28 @@ class TestSempai(unittest.TestCase):
 
     def test_location(self):
         del sys.modules['sempai'] # force the module to be reloaded
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual(os.path.join(self.direc, 'sempai.json'),
                          sempai.__file__)
 
     def test_array(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual({"nested": "but dotted"},
                          sempai.array[0])
     def test_array_dotting(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual('but dotted', sempai.array[0].nested)
 
     def test_array_nested_dotting(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertEqual('dotted', sempai.array[1].array[0].and_nested_again)
 
     def test_obj_in_list_in_list(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import sempai
         self.assertTrue(sempai.lots_of_lists[0][0].in_da_list)
 
@@ -100,7 +100,7 @@ class TestSempai(unittest.TestCase):
         with open(os.path.join(self.direc, 'invalid.json'), 'w') as f:
             f.write('not a valid json file')
 
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             self.assertRaises(ImportError, __import__, 'invalid')
 
 
@@ -123,13 +123,13 @@ class TestSempaiPackages(unittest.TestCase):
         shutil.rmtree(self.direc)
 
     def test_import_from_package(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             from python_package import nested
 
         self.assertEqual(3, nested.three)
 
     def test_import_package(self):
-        with jsonsempai.imports():
+        with jsonsempai.notice():
             import python_package.nested
 
         self.assertEqual(3, python_package.nested.three)


### PR DESCRIPTION
# Description

In order to thematically maintain the senpai narrative of json, I
propose keeping in character by changing the implementation of
`imports` to `notice.` Since the current preferred method is importing
`magic` which essentially does the same thing as `imports`, changing
this method to `senpai` will keep with the theme and allow `jsonsenpai`
to notice me.

In addition, `imp` is a depreciated lib, so I changed that to `types` instead. The
same functionality takes place. I also cleaned up some formatting
because senpai likes his code neat.
## Before

```
with jsonsempai.imports():
    import me
```
## After

```
with jsonsempai.notice():
    import me
```
