### PR TITLE
Auto code eval

### DIFF
--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -9,13 +9,23 @@ class DottedDict(dict):
 
     def __getattr__(self, attr):
         try:
-            return self[attr]
+            return wrap_unicode(self[attr])
         except KeyError:
             raise AttributeError("'{}'".format(attr))
 
     __setattr__ = dict.__setitem__
 
     __delattr__ = dict.__delitem__
+
+
+class UnicodeCode(unicode):
+
+    def __call__(self, *args, **kwargs):
+        return eval(self)(*args, **kwargs)
+
+
+def wrap_unicode(value):
+    return UnicodeCode(value) if isinstance(value, basestring) else value
 
 
 def get_json_path(directory, name):
@@ -42,7 +52,6 @@ class SempaiLoader(object):
                 if json_path is not None:
                     return cls(json_path)
 
-
     def load_module(self, name):
         if name in sys.modules:
             return sys.modules[name]
@@ -63,7 +72,7 @@ class SempaiLoader(object):
             raise ImportError(
                 'Could not open "{name}".'.format(name=self.json_path))
 
-        mod.__dict__.update(d)
+        mod.__dict__.update({k: wrap_unicode(v) for k, v in d.iteritems()})
 
         sys.modules[name] = mod
         return mod

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -18,7 +18,7 @@ class DottedDict(dict):
     __delattr__ = dict.__delitem__
 
 
-class UnicodeCode(unicode):
+class UnicodeCode(str):
 
     def __call__(self, *args, **kwargs):
         return eval(self)(*args, **kwargs)
@@ -72,7 +72,7 @@ class SempaiLoader(object):
             raise ImportError(
                 'Could not open "{name}".'.format(name=self.json_path))
 
-        mod.__dict__.update({k: wrap_unicode(v) for k, v in d.iteritems()})
+        mod.__dict__.update(dict((k, wrap_unicode(v)) for k, v in d.iteritems()))
 
         sys.modules[name] = mod
         return mod

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -18,6 +18,12 @@ class DottedDict(dict):
     __delattr__ = dict.__delitem__
 
 
+try:
+    basestring = basestring
+except NameError:
+    basestring = (str, bytes)
+
+
 class UnicodeCode(str):
 
     def __call__(self, *args, **kwargs):

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -72,7 +72,7 @@ class SempaiLoader(object):
             raise ImportError(
                 'Could not open "{name}".'.format(name=self.json_path))
 
-        mod.__dict__.update(dict((k, wrap_unicode(v)) for k, v in d.iteritems()))
+        mod.__dict__.update(dict((k, wrap_unicode(v)) for k, v in d.items()))
 
         sys.modules[name] = mod
         return mod

--- a/jsonsempai/tests/test_sempai.py
+++ b/jsonsempai/tests/test_sempai.py
@@ -110,7 +110,8 @@ class TestSempai(unittest.TestCase):
         with jsonsempai.imports():
             import sempai
         eval_code = eval(sempai.code)
-        self.assertEqual(map(sempai.code, sempai.args), map(eval_code, sempai.args))
+        self.assertEqual(list(map(sempai.code, sempai.args)),
+                         list(map(eval_code, sempai.args)))
 
 
 class TestSempaiPackages(unittest.TestCase):

--- a/jsonsempai/tests/test_sempai.py
+++ b/jsonsempai/tests/test_sempai.py
@@ -19,7 +19,9 @@ TEST_FILE = '''{
             {"and_nested_again": "dotted"}
         ]}
     ],
-    "lots_of_lists": [[{"in_da_list": true}]]
+    "lots_of_lists": [[{"in_da_list": true}]],
+    "code": "lambda x: x + 1",
+    "args": [1, 2, 3]
 }'''
 
 
@@ -81,6 +83,7 @@ class TestSempai(unittest.TestCase):
             import sempai
         self.assertEqual({"nested": "but dotted"},
                          sempai.array[0])
+
     def test_array_dotting(self):
         with jsonsempai.imports():
             import sempai
@@ -102,6 +105,12 @@ class TestSempai(unittest.TestCase):
 
         with jsonsempai.imports():
             self.assertRaises(ImportError, __import__, 'invalid')
+
+    def test_eval_code(self):
+        with jsonsempai.imports():
+            import sempai
+        eval_code = eval(sempai.code)
+        self.assertEqual(map(sempai.code, sempai.args), map(eval_code, sempai.args))
 
 
 class TestSempaiPackages(unittest.TestCase):


### PR DESCRIPTION
Implements the option to `eval` any string in the json as code by just calling it:

``` python
TEST_FILE='''{
    "code": "lambda x: x + 1"
}'''

>>> from jsonsempai import magic
>>> import tester
>>> tester.code(1)
2
```

Makes the option to outsource your backend programming directly to your API clients/consumers that much easier.
