### PR TITLE
YAML and XML support... 

### DIFF
--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -5,9 +5,16 @@ import os
 import sys
 
 try:
-    import yaml 
+    import yaml
 except:
-    pass #the lack of yaml is handled later
+    pass
+    
+try: 
+    import xmltodict
+except:
+    pass
+
+
 
 class DottedDict(dict):
 
@@ -16,20 +23,39 @@ class DottedDict(dict):
             return self[attr]
         except KeyError:
             raise AttributeError("'{}'".format(attr))
-
+            
     __setattr__ = dict.__setitem__
-
     __delattr__ = dict.__delitem__
+    
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self,obj):
+        if hasattr(obj, 'isoformat'):
+            return obj.isoformat()
+        elif isinstance(obj, decimal.Decimal):
+            return float(obj)
+        elif isinstanc(obj, ModelState):
+            return None
+        else:
+            return json.JSONEncoder.default(self, obj)
+
+
 
 def get_yaml_path(directory, name):
     yaml_path = os.path.join(directory, '{name}.yaml'.format(name=name))
     if os.path.isfile(yaml_path):
         return yaml_path
 
+def get_xml_path(directory, name):
+    xml_path = os.path.join(directory, '{name}.xml'.format(name=name))
+    if os.path.isfile(xml_path):
+        return xml_path
+
 def get_json_path(directory, name):
     json_path = os.path.join(directory, '{name}.json'.format(name=name))
     if os.path.isfile(json_path):
         return json_path
+        
+        
 
 
 class SempaiLoader(object):
@@ -39,18 +65,19 @@ class SempaiLoader(object):
     @classmethod
     def find_module(cls, name, path=None):
         for d in sys.path:
-            markup_path = get_json_path(d, name)
-            if markup_path is None:
-                markup_path = get_yaml_path(d, name)
+            markup_path = None
+            for get_markup_path in [get_json_path, get_yaml_path, get_xml_path]:
+                if markup_path is None:
+                    markup_path = get_markup_path(d, name)
             if markup_path is not None:
                 return cls(markup_path)
 
         if path is not None:
             name = name.split('.')[-1]
             for d in path:
-                markup_path = get_json_path(d, name)
-                if markup_path is None:
-                    markup_path = get_yaml_path(d, name)
+                for get_markup_path in [get_json_path, get_yaml_path, get_xml_path]:
+                    if markup_path is None:
+                        markup_path = get_markup_path(d, name)
                 if markup_path is not None:
                     return cls(markup_path)
 
@@ -65,35 +92,29 @@ class SempaiLoader(object):
 
         decoder = json.JSONDecoder(object_hook=DottedDict)
 
-        if self.markup_path[-4:] == "json":
-            try:
-                with open(self.markup_path, 'r') as f:
-                    d = decoder.decode(f.read())
-            except ValueError:
-                raise ImportError(
-                    '"{name}" does not contain a valid json.'.format(name=self.markup_path))
-            except:
-                raise ImportError(
-                    'Could not open "{name}".'.format(name=self.markup_path))  
-                    
-        elif self.markup_path[-4:] == "yaml":
-            try:
-                with open(self.markup_path, 'r') as f:
-                   d = yaml.load(f.read())
-            except ValueError:
-                raise ImportError(
-                    '"{name}" does not contain a valid yaml.'.format(name=self.markup_path))
-            except NameError:
-                raise ImportError(
-                    '"{name}" was not imported as no yaml parser is available on the system.'.format(name=self.markup_path))
-            except:
-                raise ImportError(
-                    'Could not open "{name}".'.format(name=self.markup_path))    
-
-        else:
+        
+        try:
+            markup = self.markup_path.split(".")[-1]
+            with open(self.markup_path, 'r') as f:
+                if markup == 'json':
+                   d = decoder.decode(f.read())
+                elif markup == 'xml':
+                   x = xmltodict.parse(f.read())
+                   d = decoder.decode(json.dumps(x, indent=4, cls=DateTimeEncoder).replace("@", ""))       
+                elif markup == 'yaml':
+                   y = yaml.load(f.read())
+                   d = decoder.decode(json.dumps(y, indent=4, cls=DateTimeEncoder))
+        except ValueError:
             raise ImportError(
-                'Could not open "{name}".'.format(name=self.markup_path))
-
+                '"{name}" does not contain a valid {markup}.'.format(name=self.markup_path, markup=markup))
+        except NameError:
+            raise ImportError(
+                '"{name}" was not imported as no {markup} parser is available on the system.'.format(name=self.markup_path, markup=markup))
+        except:
+            raise ImportError(
+                'Could not open "{name}".'.format(name=self.markup_path))    
+        
+        
         mod.__dict__.update(d)
 
         sys.modules[name] = mod

--- a/jsonsempai/sempai.py
+++ b/jsonsempai/sempai.py
@@ -23,7 +23,7 @@ class DottedDict(dict):
             return self[attr]
         except KeyError:
             raise AttributeError("'{}'".format(attr))
-            
+   
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
     
@@ -40,22 +40,11 @@ class DateTimeEncoder(json.JSONEncoder):
 
 
 
-def get_yaml_path(directory, name):
-    yaml_path = os.path.join(directory, '{name}.yaml'.format(name=name))
-    if os.path.isfile(yaml_path):
-        return yaml_path
+def get_markup_path(directory, name, markup):
+    markup_path = os.path.join(directory, '{name}.{markup}'.format(name=name, markup=markup))       
+    if os.path.isfile(markup_path):
+        return markup_path
 
-def get_xml_path(directory, name):
-    xml_path = os.path.join(directory, '{name}.xml'.format(name=name))
-    if os.path.isfile(xml_path):
-        return xml_path
-
-def get_json_path(directory, name):
-    json_path = os.path.join(directory, '{name}.json'.format(name=name))
-    if os.path.isfile(json_path):
-        return json_path
-        
-        
 
 
 class SempaiLoader(object):
@@ -66,18 +55,18 @@ class SempaiLoader(object):
     def find_module(cls, name, path=None):
         for d in sys.path:
             markup_path = None
-            for get_markup_path in [get_json_path, get_yaml_path, get_xml_path]:
+            for markup in ['json', 'yaml', 'xml']:
                 if markup_path is None:
-                    markup_path = get_markup_path(d, name)
+                    markup_path = get_markup_path(d, name, markup)
             if markup_path is not None:
                 return cls(markup_path)
 
         if path is not None:
             name = name.split('.')[-1]
             for d in path:
-                for get_markup_path in [get_json_path, get_yaml_path, get_xml_path]:
+                for markup in ['json', 'yaml', 'xml']:
                     if markup_path is None:
-                        markup_path = get_markup_path(d, name)
+                        markup_path = get_markup_path(d, name, markup)
                 if markup_path is not None:
                     return cls(markup_path)
 
@@ -92,7 +81,6 @@ class SempaiLoader(object):
 
         decoder = json.JSONDecoder(object_hook=DottedDict)
 
-        
         try:
             markup = self.markup_path.split(".")[-1]
             with open(self.markup_path, 'r') as f:


### PR DESCRIPTION
Even though the script is called _json_-sempai, I couldn't help but add some more markup support. 
JSON has the top priority, and yaml and xmltodict dependencies are optional, so people who wish to use _jsonsempai_ for JSON imports should not see any change, while the others will able to use the import syntax for xml and yaml. JSON files are still priority, so if a directory contains XXX.json, XXX.yaml and XXX.xml, it's the JSON one which will be imported.

Optional dependencies are now **[PyYaml](http://pyyaml.org)** and **[xmltodict](https://github.com/martinblech/xmltodict)**, both available through _pip_.

Changed every variable called json_path to markup_path for less confusion.

Import go through JSON serialization and deserialization, as JSONEncoder is the only encoder with object_hook support. That means we have to do ::

```
decoder = json.JSONDecoder(object_hook=DottedDict)
y = yaml.load(f.read())
d = decoder.decode(json.dumps(y, indent=4, cls=DateTimeEncoder))
...
mod.__dict__.update(d) 
```

instead of something like

```
y = yaml.load(f.read(), object_hook=DottedDict)
mod.__dict__update(y)
```

at the cost of code efficiency, I suppose. But for an import that only happens one time, I guess it's no big deal (and it would require to add changes to

XML imports might be the least efficient in time, as xmltodict deserializes the XML to an ordered dict and requires to edit the keys so that they can be accessible trough DottedDict. That means the xml needs to be read fully at least two times
